### PR TITLE
Fixed the absolute folder name generation of the ipynb file

### DIFF
--- a/lib/jekyll-jupyter-notebook/tag.rb
+++ b/lib/jekyll-jupyter-notebook/tag.rb
@@ -27,7 +27,7 @@ module JekyllJupyterNotebook
 
     def render(context)
       notebook_path = File.join(context["site"]["source"],
-                                context["page"]["dir"],
+                                File.dirname(context["page"]["path"]),
                                 @notebook_path)
       Dir.mktmpdir do |output|
         system("jupyter",


### PR DESCRIPTION
For some reason, using Jekyll 3.5.2, your gem doesn't work, raising the following error:

```
Liquid Exception: no implicit conversion of nil into String in /srv/jekyll/www/_posts/2017-08-23-example-with-jupyter.md
```

I'm not a web developer and I'm not familiar with Ruby, but I managed to fix it with the commit of this PR. Not sure it is the cleanest way proceed.