### PR TITLE
Added support for dynamic argument resolution in tag

### DIFF
--- a/example/_posts/2017-09-03-blog.md
+++ b/example/_posts/2017-09-03-blog.md
@@ -5,8 +5,15 @@ title: Blog
 
 ## Blog
 
-Here is a Jupyter Notebook on Blog:
+Here is a Jupyter Notebook on Blog using a string literal:
 
 {::nomarkdown}
 {% jupyter_notebook /notebooks/blog.ipynb %}
+{:/nomarkdown}
+
+Here is the same Jupyter Notebook on Blog using a variable:
+
+{::nomarkdown}
+{% assign notebook_path = "/notebooks/blog.ipynb" %}
+{% jupyter_notebook notebook_path: notebook_path %}
 {:/nomarkdown}

--- a/example/_posts/2017-09-03-blog.md
+++ b/example/_posts/2017-09-03-blog.md
@@ -1,19 +1,19 @@
 ---
 layout: default
-title: Blog
+title: Blog title
 ---
 
-## Blog
+## Blog title
 
 Here is a Jupyter Notebook on Blog using a string literal:
 
 {::nomarkdown}
-{% jupyter_notebook /notebooks/blog.ipynb %}
+{% jupyter_notebook "/notebooks/blog.ipynb" %}
 {:/nomarkdown}
 
 Here is the same Jupyter Notebook on Blog using a variable:
 
 {::nomarkdown}
 {% assign notebook_path = "/notebooks/blog.ipynb" %}
-{% jupyter_notebook notebook_path: notebook_path %}
+{% jupyter_notebook notebook_path %}
 {:/nomarkdown}

--- a/example/index.md
+++ b/example/index.md
@@ -7,7 +7,7 @@ title: Top
 
 Here is a Jupyter Notebook:
 
-{% jupyter_notebook python.ipynb %}
+{% jupyter_notebook "python.ipynb" %}
 
 ### Raw rendered pages
 
@@ -16,3 +16,9 @@ Here is a Jupyter Notebook:
 ### Other kernels
 
   * [IRuby kernel](ruby/)
+
+### Blog posts
+
+{% for post in site.posts %}
+  * [{{ post.title }} ({{ post.date | date: "%Y-%m-%d" }})]({{ post.url }})
+{% endfor %}

--- a/example/ruby/index.md
+++ b/example/ruby/index.md
@@ -8,5 +8,5 @@ title: Ruby
 Here is a Jupyter Notebook with IRuby kernel:
 
 {::nomarkdown}
-{% jupyter_notebook ruby.ipynb %}
+{% jupyter_notebook "ruby.ipynb" %}
 {:/nomarkdown}

--- a/lib/jekyll-jupyter-notebook/tag.rb
+++ b/lib/jekyll-jupyter-notebook/tag.rb
@@ -18,7 +18,15 @@ module JekyllJupyterNotebook
 
     def initialize(tag_name, markup, tokens)
       super
-      @notebook_path = markup.strip
+      markup.scan(Liquid::TagAttributes) do |key, value|
+        if key == "notebook_path"
+          @renderUsingContext = true
+          @notebook_path = value.gsub(/^'|"/, '').gsub(/'|"$/, '')
+        end
+      end
+      if !@notebook_path
+        @notebook_path = markup.strip
+      end
     end
 
     def syntax_example
@@ -26,6 +34,9 @@ module JekyllJupyterNotebook
     end
 
     def render(context)
+      if @renderUsingContext
+        @notebook_path = context[@notebook_path]
+      end
       notebook_html_path = "#{@notebook_path}.html"
       <<-HTML
 <div

--- a/lib/jekyll-jupyter-notebook/tag.rb
+++ b/lib/jekyll-jupyter-notebook/tag.rb
@@ -16,28 +16,24 @@ module JekyllJupyterNotebook
   class Tag < Liquid::Tag
     Liquid::Template.register_tag("jupyter_notebook", self)
 
-    def initialize(tag_name, markup, tokens)
+    def initialize(tag_name, markup, parse_context)
       super
-      markup.scan(Liquid::TagAttributes) do |key, value|
-        if key == "notebook_path"
-          @renderUsingContext = true
-          @notebook_path = value.gsub(/^'|"/, '').gsub(/'|"$/, '')
-        end
-      end
-      if !@notebook_path
-        @notebook_path = markup.strip
-      end
     end
 
     def syntax_example
-      "{% #{@tag_name} filename.ipynb %} or {% #{@tag_name} notebook_path: filename.ipynb %}"
+      "{% #{@tag_name} \"filename.ipynb\" %}"
     end
 
     def render(context)
-      if @renderUsingContext
-        @notebook_path = context[@notebook_path]
+      variable = Liquid::Variable.new(@markup, @parse_context)
+      notebook_path = variable.render(context)
+      if notebook_path.nil?
+        Jekyll.logger.warn("Warning:",
+                           "Jupyter Notebook path be string literal: " +
+                           "<#{@markup.strip.inspect}>")
+        notebook_path = @markup.strip # For backward compatibility
       end
-      notebook_html_path = "#{@notebook_path}.html"
+      notebook_html_path = "#{notebook_path}.html"
       <<-HTML
 <div
   class="jupyter-notebook"

--- a/lib/jekyll-jupyter-notebook/tag.rb
+++ b/lib/jekyll-jupyter-notebook/tag.rb
@@ -30,7 +30,7 @@ module JekyllJupyterNotebook
     end
 
     def syntax_example
-      "{% #{@tag_name} filename.ipynb %}"
+      "{% #{@tag_name} filename.ipynb %} or {% #{@tag_name} notebook_path: filename.ipynb %}"
     end
 
     def render(context)

--- a/lib/jekyll-jupyter-notebook/version.rb
+++ b/lib/jekyll-jupyter-notebook/version.rb
@@ -11,5 +11,5 @@
 # limitations under the License.
 
 module JekyllJupyterNotebook
-  VERSION = "0.0.5"
+  VERSION = "0.0.4"
 end

--- a/lib/jekyll-jupyter-notebook/version.rb
+++ b/lib/jekyll-jupyter-notebook/version.rb
@@ -11,5 +11,5 @@
 # limitations under the License.
 
 module JekyllJupyterNotebook
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end


### PR DESCRIPTION
Hi,

I thought instead of raising an issue I'd make this quite simple change myself. I'd love to see this feature in the main repository so I can point my gem include back to it.

## Problem
I'm building a theme where each post may have a front-matter variable naming a Jupyter Notebook file to display. The tag is included in the post template, positioned separately from the content of the post, and therefore the notebook's path cannot be hard-coded. Attempting to pass a variable into the tag in its current state does not work, e.g.

```
_posts
  2018-06-06-my-post.md <-- Has front matter variable "notebook_path" set to "test.ipynb"
_layouts
  post.html <-- Uses custom jupyter tag
```

```
{% assign notebook_path = "/assets/notebooks/" | append: page.notebook_path %}
<!-- By this point notebook_path resolves to "/assets/notebooks/test.ipynb" -->
{% jupyter_notebook notebook_path %}
<!-- Uh-oh! This attempts to render '/notebook_path.html' in the iframe -->
```

## Solution
Googling around, it seems a short, clean and extensible solution to parsing tag parameters is to scan the markup argument for tag attributes and switch on relevant ones. I set a flag if it appears the user is attempting to denote the path as a variable, e.g.

`{% jupyter_notebook notebook_path: my_variable %}`

If this flag is set when render is called, it uses the page context to resolve the variable name to its value, replacing the notebook_path string literal text with something dynamic. Otherwise, it falls back to said string.

## Notes
The change is backward compatible - it only triggers if there is a colon following the parameter name e.g.

```
{% jupyter_notebook notebook_path %}
<!-- This still attempts to render '/notebook_path.html' in the iframe -->
```

I've also incremented the build number and updated your documentation method. Because I'm unsure of your build chain, and there was no contribution guide, feel free to let me know if there are steps I have missed in order to conform with your repository's standards.