### PR TITLE
Use the --no-prompt flag to hide In[], Out[]

### DIFF
--- a/lib/jekyll-jupyter-notebook/converter.rb
+++ b/lib/jekyll-jupyter-notebook/converter.rb
@@ -50,6 +50,7 @@ module JekyllJupyterNotebook
         pid = spawn("jupyter",
                     "nbconvert",
                     "--to", "html",
+                    "--no-prompt",
                     "--stdout",
                     notebook.path,
                     :out => output)


### PR DESCRIPTION
fix #9

added the --no-prompt flag to nbconvert

this way, we can hide In[] , Out[]. 

However, we should make this an optional case. 