### PR TITLE
Add "input" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ jupyter_notebook:
 
 ### `input`
 
-Similar to how `prompt` works, you can also control whether a converted `.html` includes code inputs or not by using `inputs`:
+Similar to how `prompt` works, you can also control whether a converted `.html` includes code inputs or not by using `input`:
 
 ```yaml
 jupyter_notebook:

--- a/README.md
+++ b/README.md
@@ -80,6 +80,24 @@ jupyter_notebook:
   prompt: false
 ```
 
+### `input`
+
+Similar to how `prompt` works, you can also control whether a converted `.html` includes code inputs or not by using `inputs`:
+
+```yaml
+jupyter_notebook:
+  input: true
+```
+
+The default value is `true`. It means that input code blocks are shown.
+
+You can remove them by using `false`:
+
+```yaml
+jupyter_notebook:
+  input: false
+```
+
 ## Authors
 
 * Kouhei Sutou \<kou@clear-code.com\>

--- a/lib/jekyll-jupyter-notebook/converter.rb
+++ b/lib/jekyll-jupyter-notebook/converter.rb
@@ -53,8 +53,8 @@ module JekyllJupyterNotebook
           "--to", "html",
           "--stdout",
         ]
-        command_line << "--no-prompt" unless config.fetch("prompt", true)
         command_line << "--no-input" unless config.fetch("input", true)
+        command_line << "--no-prompt" unless config.fetch("prompt", true)
         command_line << notebook.path
         pid = spawn(*command_line, out: output)
         begin

--- a/lib/jekyll-jupyter-notebook/converter.rb
+++ b/lib/jekyll-jupyter-notebook/converter.rb
@@ -54,6 +54,7 @@ module JekyllJupyterNotebook
           "--stdout",
         ]
         command_line << "--no-prompt" unless config.fetch("prompt", true)
+        command_line << "--no-input" unless config.fetch("input", true)
         command_line << notebook.path
         pid = spawn(*command_line, out: output)
         begin


### PR DESCRIPTION
GitHub: fix GH-12

It controls wheter a converted `.html` includes code inputs or not.

### Changes:

- Updated  `README.md ` to include the new feature description
- Added the `--no-input` command line argument in `converter.rb`, similar to how it was implemented for `--no-prompt`. Both features follow the same logic.